### PR TITLE
Update JLL version to 2.2.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ RadeonProRender_jll = "e92fa02b-1b7a-5e4e-a5cb-14fe26dfc45b"
 CEnum = "0.4"
 Colors = "0.9, 0.10, 0.11, 0.12"
 GeometryBasics = "0.4.1"
-RadeonProRender_jll = "=2.2.9"
+RadeonProRender_jll = "=2.2.12"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RadeonProRender"
 uuid = "27029320-176d-4a42-b57d-56729d2ad457"
 authors = ["Simon Danisch"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"


### PR DESCRIPTION
Updates the RadeonProRender_jll version to be fixed to 2.2.12, and bumps the version up by a minor increment.