### PR TITLE
Updates for GeometryBasics

### DIFF
--- a/src/highlevel-api.jl
+++ b/src/highlevel-api.jl
@@ -280,13 +280,9 @@ abstract type AbstractLight{PtrType} <: RPRObject{PtrType} end
 Default shape constructor which works with every Geometry from the package
 GeometryTypes (Meshes and geometry primitives alike).
 """
-function Shape(context::Context, meshlike; kw...)
+function Shape(context::Context, meshlike::GeometryBasics.Mesh; kw...)
     m = uv_normal_mesh(meshlike; kw...)
-    v, n, fs, uv = decompose(Point3f, m), normals(m), faces(m), texturecoordinates(m)
-    if isnothing(n)
-        n = normals(v, fs)
-    end
-    return Shape(context, v, n, fs, uv)
+    return Shape(context, decompose(Point3f, m), decompose_normals(m), faces(m), decompose_uv(m))
 end
 
 #=

--- a/src/highlevel-api.jl
+++ b/src/highlevel-api.jl
@@ -280,7 +280,7 @@ abstract type AbstractLight{PtrType} <: RPRObject{PtrType} end
 Default shape constructor which works with every Geometry from the package
 GeometryTypes (Meshes and geometry primitives alike).
 """
-function Shape(context::Context, meshlike::GeometryBasics.Mesh; kw...)
+function Shape(context::Context, meshlike::GeometryBasics.AbstractGeometry; kw...)
     m = uv_normal_mesh(meshlike; kw...)
     return Shape(context, decompose(Point3f, m), decompose_normals(m), faces(m), decompose_uv(m))
 end

--- a/src/highlevel-api.jl
+++ b/src/highlevel-api.jl
@@ -280,7 +280,7 @@ abstract type AbstractLight{PtrType} <: RPRObject{PtrType} end
 Default shape constructor which works with every Geometry from the package
 GeometryTypes (Meshes and geometry primitives alike).
 """
-function Shape(context::Context, meshlike::GeometryBasics.AbstractGeometry; kw...)
+function Shape(context::Context, meshlike; kw...)
     m = uv_normal_mesh(meshlike; kw...)
     return Shape(context, decompose(Point3f, m), decompose_normals(m), faces(m), decompose_uv(m))
 end


### PR DESCRIPTION
Changes for https://github.com/MakieOrg/Makie.jl/pull/4319 / https://github.com/JuliaGeometry/GeometryBasics.jl/pull/219

Important changes:
- allow uvs to be nothing (GeometryBasics no longer defaults to using `Vec2f.(mesh.position)` for 3D)